### PR TITLE
Add FEE_LIMIT_PERCENT setting

### DIFF
--- a/boltcard.service
+++ b/boltcard.service
@@ -39,7 +39,9 @@ Environment="LN_PORT=10009"
 Environment="LN_TLS_FILE=/home/ubuntu/boltcard/tls.cert"
 Environment="LN_MACAROON_FILE=/home/ubuntu/boltcard/SendPaymentV2.macaroon"
 
-# FEE_LIMIT_SAT is the maximum lightning network fee to be paid
+# The maximum lightning network fee to be paid in percent of the payment amount.
+Environment="FEE_LIMIT_PERCENT=0.5"
+# Acceptable flat fee in sats that can exceed the percentage limit.
 Environment="FEE_LIMIT_SAT=10"
 
 # email

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,7 +14,7 @@ This will give you a new 128 bit random key as a 32 character hex value.
 
 This is due to your payment lightning node not finding a route to the merchant lightning node.  
 It may help to open well funded channels to other well connected nodes.  
-It may also help to increase your maximum network fee in your service variables, **FEE_LIMIT_SAT** .  
+It may also help to increase your maximum network fee in your service variables, **FEE_LIMIT_SAT** / **FEE_LIMIT_PERCENT** .  
 It can be useful to test paying invoices directly from your lightning node.  
 
 > Why do my payments take so long ?  


### PR DESCRIPTION
This allows you to set a percentage fee limit instead of just a flat value. In order for a transaction to go through, the fee has to satisfy either the flat or the percentage limit.

This is useful because lightning fees naturally depend on the transaction amount, and for larger transactions you are probably willing to pay a higher flat fee.

**Example**
With a percentage limit of 0.5% and a flat limit of 10 stas, the maximum fee is 10 sats for transactions up to 2000 and 0.5% of the amount for the rest.