### PR TITLE
Make the fee limit the sum of base + percentage

### DIFF
--- a/boltcard.service
+++ b/boltcard.service
@@ -43,10 +43,9 @@ Environment="LN_PORT=10009"
 Environment="LN_TLS_FILE=/home/ubuntu/boltcard/tls.cert"
 Environment="LN_MACAROON_FILE=/home/ubuntu/boltcard/SendPaymentV2.macaroon"
 
-# The maximum lightning network fee to be paid in percent of the payment amount.
+# The maximum lightning network fee to be paid is the base FEE_LIMIT_SAT + the FEE_LIMIT_PERCENT of the amount.
+Environment="FEE_LIMIT_SAT=5"
 Environment="FEE_LIMIT_PERCENT=0.5"
-# Acceptable flat fee in sats that can exceed the percentage limit.
-Environment="FEE_LIMIT_SAT=10"
 
 # email
 # Environment="AWS_SES_ID="

--- a/lightning.go
+++ b/lightning.go
@@ -228,9 +228,6 @@ func pay_invoice(card_payment_id int, invoice string) {
 	invoice_msats := bolt11.MSatoshi
 
 	fee_limit_product := int64((fee_limit_percent / 100) * (float64(invoice_msats) / 1000))
-	if fee_limit_product > fee_limit_sat {
-		fee_limit_sat = fee_limit_product
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -239,7 +236,7 @@ func pay_invoice(card_payment_id int, invoice string) {
 		PaymentRequest:    invoice,
 		NoInflightUpdates: true,
 		TimeoutSeconds:    30,
-		FeeLimitSat:       fee_limit_sat})
+		FeeLimitSat:       fee_limit_sat + fee_limit_product})
 
 	if err != nil {
        	        log.WithFields(log.Fields{"card_payment_id": card_payment_id}).Warn(err)


### PR DESCRIPTION
I just realized that this is probably more intuitive. Limit = base + percentage instead of whichever is higher. This is more aligned with how you normally estimate fees.

Not sure what the default values should be.