### PR TITLE
LN invoice expiry param & use it for ctx timeout

### DIFF
--- a/docker_init.sh
+++ b/docker_init.sh
@@ -32,3 +32,4 @@ sed -i "s/[(]'FEE_LIMIT_PERCENT'[^)]*[)]/(\'FEE_LIMIT_PERCENT\', \'0.5\')/" sql/
 sed -i "s/[(]'FUNCTION_LNURLW'[^)]*[)]/(\'FUNCTION_LNURLW\', \'ENABLE\')/" sql/settings.sql
 sed -i "s/[(]'FUNCTION_LNURLP'[^)]*[)]/(\'FUNCTION_LNURLP\', \'DISABLE\')/" sql/settings.sql
 sed -i "s/[(]'FUNCTION_EMAIL'[^)]*[)]/(\'FUNCTION_EMAIL\', \'DISABLE\')/" sql/settings.sql
+sed -i "s/[(]'LN_INVOICE_EXPIRY_SEC'[^)]*[)]/(\'LN_INVOICE_EXPIRY_SEC\', \'3600\')/" sql/settings.sql

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -34,3 +34,4 @@ Here are the descriptions of values available to use in the `settings` table:
 | FUNCTION_INTERNAL_API | DISABLE | system level switch for activating the internal API |
 | SENDGRID_API_KEY      | | User API Key from SendGrid.com             |
 | SENDGRID_EMAIL_SENDER | | Single Sender email address verified by SendGrid |
+| LN_INVOICE_EXPIRY_SEC | 3600 | LN invoice's expiry time in seconds |

--- a/sql/settings.sql
+++ b/sql/settings.sql
@@ -31,3 +31,4 @@ INSERT INTO settings (name, value) VALUES ('LNDHUB_URL', '');
 INSERT INTO settings (name, value) VALUES ('FUNCTION_INTERNAL_API', '');
 INSERT INTO settings (name, value) VALUES ('SENDGRID_API_KEY', '');
 INSERT INTO settings (name, value) VALUES ('SENDGRID_EMAIL_SENDER', '');
+INSERT INTO settings (name, value) VALUES ('LN_INVOICE_EXPIRY_SEC', '3600');


### PR DESCRIPTION
This PR add new settings named "LN_INVOICE_EXPIRY_SEC" for LN invoice expiry time in seconds and set its default to 3600 (1 hour). It also use this value when requsting an invoice from LN and and set the context for montoring connection timeout to it.
this should allow late payments ( more than 30s) to be monitored by boltcard service. 